### PR TITLE
게시글 미리보기 - 성인 콘텐츠 관련 게시글 미리보기 비활성화

### DIFF
--- a/addon/article-thumb.js
+++ b/addon/article-thumb.js
@@ -101,6 +101,8 @@ async function loadThumbnail(img, id) {
 
     if (!thumbnailUrl) {
         const data = await memicUtils.api.articles.get(id);
+        if (data.board.name === "후방주의" || data.isOnlyAdult === true) return;
+
         thumbnailUrl = extractThumbnailUrl(data.content);
     }
 

--- a/addon/article-thumb.js
+++ b/addon/article-thumb.js
@@ -1,8 +1,8 @@
 const addonInfo = {
     name: "미밐 글 썸네일 미리보기",
     description: "미밐 글의 썸네일을 마우스 오버시 미리보기로 표시합니다.",
-    author: "raws6633",
-    version: "1.0.0",
+    author: "isnoa, raws6633",
+    version: "1.0.1",
     link: "https://github.com/isnoa/memic-utils"
 }
 


### PR DESCRIPTION
성인 콘텐츠 주의(`후방주의` 탭 또는 `isOnlyAdults`: true)가 있는 게시글에 대해
  - 미리보기 기능이 작동하지 않도록 return 처리
 사유: https://shelter.id/articles/624112
 
 켜고 끄는 기능을 넣는 것이 좋을 수도